### PR TITLE
[ETC] USER 쪽 List로 선언된 ProfilePhotos, Hobbys, Interests와 각자 엔티티의 연관관계(1:n) 설정 및 수정

### DIFF
--- a/src/main/java/com/wooyeon/yeon/likeManage/domain/Like.java
+++ b/src/main/java/com/wooyeon/yeon/likeManage/domain/Like.java
@@ -1,5 +1,8 @@
 package com.wooyeon.yeon.likeManage.domain;
 
+import com.wooyeon.yeon.profileChoice.domain.Match;
+import com.wooyeon.yeon.user.domain.User;
+
 import javax.persistence.*;
 
 @Entity

--- a/src/main/java/com/wooyeon/yeon/profileChoice/domain/Match.java
+++ b/src/main/java/com/wooyeon/yeon/profileChoice/domain/Match.java
@@ -2,6 +2,7 @@ package com.wooyeon.yeon.profileChoice.domain;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
+import com.wooyeon.yeon.likeManage.domain.Like;
 
 @Entity
 public class Match {

--- a/src/main/java/com/wooyeon/yeon/user/domain/Hobby.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/Hobby.java
@@ -1,12 +1,13 @@
 package com.wooyeon.yeon.user.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 public class Hobby {
     @Id
     private Long hobbyId;
-
     private String hobby;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
 }

--- a/src/main/java/com/wooyeon/yeon/user/domain/Interest.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/Interest.java
@@ -1,11 +1,13 @@
 package com.wooyeon.yeon.user.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 public class Interest {
     @Id
     private Long interestId;
     private String interest;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
 }

--- a/src/main/java/com/wooyeon/yeon/user/domain/ProfilePhoto.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/ProfilePhoto.java
@@ -1,11 +1,13 @@
 package com.wooyeon.yeon.user.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 public class ProfilePhoto {
     @Id
-    private String profilePhotoId;
+    private Long profilePhotoId;
     private String profilePhoto;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
 }

--- a/src/main/java/com/wooyeon/yeon/user/domain/User.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/User.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@RequiredArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
@@ -24,9 +23,9 @@ public class User {
     @Column(length = 50, nullable = false)
     private String nickname;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "PROFILE_PHOTO_ID")
-    private List<ProfilePhoto> profilePhoto=new ArrayList<>();
+    @Column
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "user")
+    private List<ProfilePhoto> profilePhotos=new ArrayList<>();
 
     @Column(length = 8, nullable = false)
     private String birthday;
@@ -46,28 +45,28 @@ public class User {
     @Column(length = 50)
     private String intro;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "HOBBY_ID")
-    private List<Hobby> hobby=new ArrayList<>();
+    @Column
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "user")
+    private List<Hobby> hobbys=new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "INTEREST_ID")
-    private List<Interest> interest=new ArrayList<>();
+    @Column
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "user")
+    private List<Interest> interests=new ArrayList<>();
 
     @Builder
-    public User(Long userId, String phone, char gender, String nickname, List<ProfilePhoto> profilePhoto, String birthday, String email, String locationInfo, String gpsLocationInfo, String mbti, String intro, List<Hobby> hobby, List<Interest> interest) {
+    public User(Long userId, String phone, char gender, String nickname, List<ProfilePhoto> profilePhotos, String birthday, String email, String locationInfo, String gpsLocationInfo, String mbti, String intro, List<Hobby> hobbys, List<Interest> interests) {
         this.userId=userId;
         this.phone=phone;
         this.gender=gender;
         this.nickname=nickname;
-        this.profilePhoto=profilePhoto;
+        this.profilePhotos=profilePhotos;
         this.birthday=birthday;
         this.email=email;
         this.locationInfo=locationInfo;
         this.gpsLocationInfo=gpsLocationInfo;
         this.mbti=mbti;
         this.intro=intro;
-        this.hobby=hobby;
-        this.interest=interest;
+        this.hobbys=hobbys;
+        this.interests=interests;
     }
 }

--- a/src/main/java/com/wooyeon/yeon/user/domain/User.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/User.java
@@ -15,7 +15,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long userId;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 11, nullable = false)
     private String phone;
 
     @Column(nullable = false)
@@ -28,7 +28,7 @@ public class User {
     @JoinColumn(name = "PROFILE_PHOTO_ID")
     private List<ProfilePhoto> profilePhoto=new ArrayList<>();
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 8, nullable = false)
     private String birthday;
 
     @Column(length = 100, nullable = false)
@@ -40,7 +40,7 @@ public class User {
     @Column(length = 100, nullable = false)
     private String gpsLocationInfo;
 
-    @Column(length = 20)
+    @Column(length = 4)
     private String mbti;
 
     @Column(length = 50)
@@ -70,5 +70,4 @@ public class User {
         this.hobby=hobby;
         this.interest=interest;
     }
-
 }

--- a/src/main/java/com/wooyeon/yeon/user/dto/UserDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/UserDto.java
@@ -10,7 +10,7 @@ public class UserDto {
     private String phone;
     private String gender;
     private String nickname;
-    private List<String> profilePhoto;
+    private List<String> profilePhotos;
     private String birthday;
     private String email;
     // 사용자가 직접 설정한 위치
@@ -19,6 +19,6 @@ public class UserDto {
     private String gpsLocationInfo;
     private String mbti;
     private String intro;
-    private List<String> hobby;
-    private List<String> interest;
+    private List<String> hobbys;
+    private List<String> interests;
 }

--- a/src/main/java/com/wooyeon/yeon/user/dto/UserDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/UserDto.java
@@ -1,7 +1,10 @@
 package com.wooyeon.yeon.user.dto;
 
+import lombok.Data;
+
 import java.util.List;
 
+@Data
 public class UserDto {
     private Long userId;
     private String phone;
@@ -18,5 +21,4 @@ public class UserDto {
     private String intro;
     private List<String> hobby;
     private List<String> interest;
-
 }


### PR DESCRIPTION
(1:n 연관 관계 설정 중에서, n쪽 엔티티에서만 연관 관계 설정하려고 했으나 List 선언문에서 오류가 나서 chatGPT에 물어본 결과 @OneToMany로 양방향 설정 해줘야 한다고 해서 @OneToMany도 설정 하였습니다.)