### PR TITLE
[FEAT] AES Util 추가 & 클라이언트에게 RSA로 암호화된 encryptedKey 받아와서 decode & AES KEY와 IV로 나눈 후, 해당 값으로 encryptedPassword 복호화하는 기능 구현

### DIFF
--- a/src/main/java/com/wooyeon/yeon/user/controller/UserController.java
+++ b/src/main/java/com/wooyeon/yeon/user/controller/UserController.java
@@ -86,7 +86,7 @@ public class UserController {
     // 암호화된 비밀번호와 RSA 공개키로 암호화된 AES 복호화 키 전달
     @PostMapping("/encrypt/pw")
     public PasswordEncryptResponseDto passwordEncrypt(@RequestBody PasswordEncryptRequestDto passwordEncryptRequestDto)
-            throws NoSuchPaddingException, IllegalBlockSizeException, InvalidKeySpecException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+            throws Exception {
         PasswordEncryptResponseDto passwordEncryptResponseDto = userService.decodeEncrypt(passwordEncryptRequestDto);
         return passwordEncryptResponseDto;
     }

--- a/src/main/java/com/wooyeon/yeon/user/controller/UserController.java
+++ b/src/main/java/com/wooyeon/yeon/user/controller/UserController.java
@@ -1,6 +1,9 @@
 package com.wooyeon.yeon.user.controller;
 
 import com.wooyeon.yeon.user.dto.*;
+import com.wooyeon.yeon.user.dto.emailAuth.EmailAuthResponseDto;
+import com.wooyeon.yeon.user.dto.emailAuth.EmailRequestDto;
+import com.wooyeon.yeon.user.dto.emailAuth.EmailResponseDto;
 import com.wooyeon.yeon.user.service.EmailAuthService;
 import com.wooyeon.yeon.user.service.ProfileService;
 import com.wooyeon.yeon.user.service.UserService;
@@ -12,8 +15,14 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import javax.mail.MessagingException;
 import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -75,11 +84,12 @@ public class UserController {
     }
 
     // 암호화된 비밀번호와 RSA 공개키로 암호화된 AES 복호화 키 전달
-    /*@PostMapping("/encrypt/pw")
-    public PasswordEncryptResponseDto passwordEncrypt(@RequestBody PasswordEncryptRequestDto passwordEncryptRequestDto) {
-        PasswordEncryptResponseDto passwordEncryptResponseDto;
+    @PostMapping("/encrypt/pw")
+    public PasswordEncryptResponseDto passwordEncrypt(@RequestBody PasswordEncryptRequestDto passwordEncryptRequestDto)
+            throws NoSuchPaddingException, IllegalBlockSizeException, InvalidKeySpecException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+        PasswordEncryptResponseDto passwordEncryptResponseDto = userService.decodeEncrypt(passwordEncryptRequestDto);
         return passwordEncryptResponseDto;
-    }*/
+    }
 
     // 프로필 등록
     @PostMapping(value = "/users/register/profile")

--- a/src/main/java/com/wooyeon/yeon/user/domain/User.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/User.java
@@ -39,9 +39,12 @@ public class User implements UserDetails {
 
     private String refreshToken;
 
-    @Column()
+    @Column
     private boolean emailAuth = false;
     private boolean phoneAuth = false;
+
+    @Column
+    private String salt;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "PROFILE_ID")
@@ -61,7 +64,7 @@ public class User implements UserDetails {
     }
 
     @Builder
-    public User(String email, String phone, UUID userCode, String accessToken, String refreshToken, boolean emailAuth, boolean phoneAuth) {
+    public User(String email, String phone, UUID userCode, String accessToken, String refreshToken, boolean emailAuth, boolean phoneAuth, String password, String salt) {
         this.email = email;
         this.phone = phone;
         this.userCode = userCode;
@@ -69,6 +72,8 @@ public class User implements UserDetails {
         this.refreshToken = refreshToken;
         this.emailAuth = emailAuth;
         this.phoneAuth = phoneAuth;
+        this.salt = salt;
+        this.password = password;
     }
 
     public void updateRefreshToken(String refreshToken) {
@@ -78,6 +83,9 @@ public class User implements UserDetails {
     public void updateAccessToken(String accessToken) {
         this.accessToken = accessToken;
     }
+
+    public void updatePassword(String password) { this.password = password; }
+    public void updateSalt(String salt) { this.salt = salt; }
 
     public void setProfile(Profile profile) {
         this.profile = profile;

--- a/src/main/java/com/wooyeon/yeon/user/dto/PasswordEncryptRequestDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/PasswordEncryptRequestDto.java
@@ -9,4 +9,9 @@ public class PasswordEncryptRequestDto {
     private String email;
     private String encryptedPassword;
     private String encryptedKey;
+
+    public String getEmail() { return this.email=email; }
+    public String getEncryptedPassword() { return this.encryptedPassword = encryptedPassword; }
+    public String getEncryptedKey() { return this.encryptedKey = encryptedKey; }
+
 }

--- a/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailAuthRequestDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailAuthRequestDto.java
@@ -1,4 +1,4 @@
-package com.wooyeon.yeon.user.dto;
+package com.wooyeon.yeon.user.dto.emailAuth;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailAuthResponseDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailAuthResponseDto.java
@@ -1,4 +1,4 @@
-package com.wooyeon.yeon.user.dto;
+package com.wooyeon.yeon.user.dto.emailAuth;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailRequestDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailRequestDto.java
@@ -1,4 +1,4 @@
-package com.wooyeon.yeon.user.dto;
+package com.wooyeon.yeon.user.dto.emailAuth;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailResponseDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/emailAuth/EmailResponseDto.java
@@ -1,4 +1,4 @@
-package com.wooyeon.yeon.user.dto;
+package com.wooyeon.yeon.user.dto.emailAuth;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/wooyeon/yeon/user/service/EmailAuthService.java
+++ b/src/main/java/com/wooyeon/yeon/user/service/EmailAuthService.java
@@ -1,9 +1,9 @@
 package com.wooyeon.yeon.user.service;
 
 import com.wooyeon.yeon.user.domain.EmailAuth;
-import com.wooyeon.yeon.user.dto.EmailAuthResponseDto;
-import com.wooyeon.yeon.user.dto.EmailRequestDto;
-import com.wooyeon.yeon.user.dto.EmailResponseDto;
+import com.wooyeon.yeon.user.dto.emailAuth.EmailAuthResponseDto;
+import com.wooyeon.yeon.user.dto.emailAuth.EmailRequestDto;
+import com.wooyeon.yeon.user.dto.emailAuth.EmailResponseDto;
 import com.wooyeon.yeon.user.repository.EmailAuthRepository;
 import com.wooyeon.yeon.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wooyeon/yeon/user/service/UserService.java
+++ b/src/main/java/com/wooyeon/yeon/user/service/UserService.java
@@ -1,15 +1,25 @@
 package com.wooyeon.yeon.user.service;
 
 import com.wooyeon.yeon.user.domain.User;
+import com.wooyeon.yeon.user.dto.PasswordEncryptRequestDto;
+import com.wooyeon.yeon.user.dto.PasswordEncryptResponseDto;
 import com.wooyeon.yeon.user.dto.RsaPublicResponseDto;
-import com.wooyeon.yeon.user.repository.EmailAuthRepository;
 import com.wooyeon.yeon.user.repository.UserRepository;
 import com.wooyeon.yeon.user.service.encrypt.RsaUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
 import java.util.UUID;
 
 @Slf4j
@@ -32,11 +42,95 @@ public class UserService {
 
     public RsaPublicResponseDto sendRsaPublicKey() {
         RsaPublicResponseDto rsaPublicResponseDto = RsaPublicResponseDto.builder()
-                .publicKey(rsaUtil.sendPublicKey())
+                .publicKey(RsaUtil.sendPublicKey())
                 .build();
 
-        log.info("Service public key: {}", rsaUtil.sendPublicKey());
+        log.info("Service public key: {}", RsaUtil.sendPublicKey());
 
         return rsaPublicResponseDto;
     }
+
+    public PasswordEncryptResponseDto decodeEncrypt(PasswordEncryptRequestDto passwordEncryptRequestDto)
+            throws NoSuchPaddingException, IllegalBlockSizeException, InvalidKeySpecException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+
+        // AES 암호화 키 및 IV 받아오기
+
+
+        String encryptedPassword = "ABCDEFGHI1234567";
+        log.info("RSA 공개키로 암호화 된 암호(encryptedPassword) : {}",encryptedPassword);
+
+        // RSA 개인키로 복호화해서 비밀번호 원문 받아오기
+        String decodedPassword = RsaUtil.rsaDecode(encryptedPassword, RsaUtil.sendPrivateKey());
+        log.info("password 원문 : {}", decodedPassword);
+
+        // 비밀번호 + salt를 SHA256으로 암호화
+        String salt = createSalt();
+        String password = decodedPassword+salt;
+        String finalPassword = encryptSha256(password);
+
+        // User 테이블에 저장
+        User user = User.builder()
+                .email(passwordEncryptRequestDto.getEmail())
+                .emailAuth(true)
+                .userCode(UUID.randomUUID())
+                .password(finalPassword)
+                .salt(salt)
+                .build();
+        userRepository.save(user);
+
+        // ResponseDto 구성
+        PasswordEncryptResponseDto passwordEncryptResponseDto = PasswordEncryptResponseDto.builder()
+                .statusCode(HttpStatus.SC_OK)
+                .statusName("success")
+                .build();
+        return passwordEncryptResponseDto;
+    }
+
+    // salt 생성
+    public String createSalt() {
+
+        //1. Random, byte 객체 생성
+        SecureRandom r = new SecureRandom ();
+        byte[] salt = new byte[20];
+
+        //2. 난수 생성
+        r.nextBytes(salt);
+
+        //3. byte To String (10진수의 문자열로 변경)
+        StringBuffer sb = new StringBuffer();
+        for(byte b : salt) {
+            sb.append(String.format("%02x", b));
+        };
+
+        return sb.toString();
+    }
+
+    // SHA256 암호화
+    public String encryptSha256(String password) {
+
+        String shaEncryptedPassword = "";
+        try {
+            //1. SHA256 알고리즘 객체 생성
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+
+            //2. 비밀번호와 salt 합친 문자열에 SHA 256 적용
+            md.update(password.getBytes());
+            byte[] pwdSalt = md.digest();
+
+            //3. byte To String (10진수의 문자열로 변경)
+            StringBuffer sb = new StringBuffer();
+            for (byte b : pwdSalt) {
+                sb.append(String.format("%02x", b));
+            }
+
+            shaEncryptedPassword=sb.toString();
+            log.info("SHA 암호화 후 : {}", shaEncryptedPassword);
+
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+
+        return shaEncryptedPassword;
+    }
+
 }

--- a/src/main/java/com/wooyeon/yeon/user/service/UserService.java
+++ b/src/main/java/com/wooyeon/yeon/user/service/UserService.java
@@ -53,15 +53,21 @@ public class UserService {
     public PasswordEncryptResponseDto decodeEncrypt(PasswordEncryptRequestDto passwordEncryptRequestDto)
             throws NoSuchPaddingException, IllegalBlockSizeException, InvalidKeySpecException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
 
-        // AES 암호화 키 및 IV 받아오기
+        String encryptedKey = "ABCDEFGHI1234567";
+        log.info("RSA 공개키로 암호화 된 키(decodedKey) : {}", encryptedKey);
 
+        // RSA 개인키로 복호화해서 AES Key+IV 원문 받아오기
+        String decodedKey = RsaUtil.rsaDecode(encryptedKey, RsaUtil.sendPrivateKey());
+        log.info("RSA 공개키로 복호화한 키(decodedKey) : {}", decodedKey);
 
-        String encryptedPassword = "ABCDEFGHI1234567";
-        log.info("RSA 공개키로 암호화 된 암호(encryptedPassword) : {}",encryptedPassword);
+        // IV와 AES Key로 나누기
 
-        // RSA 개인키로 복호화해서 비밀번호 원문 받아오기
-        String decodedPassword = RsaUtil.rsaDecode(encryptedPassword, RsaUtil.sendPrivateKey());
-        log.info("password 원문 : {}", decodedPassword);
+        log.info("IV: {}");
+        log.info("AES Key: {}");
+
+        // AES Key 로 비밀번호 복호화해서 원문 받아오기
+        String decodedPassword = "ABC";
+        log.info("AES로 복호화한 원문 : {}", decodedPassword);
 
         // 비밀번호 + salt를 SHA256으로 암호화
         String salt = createSalt();

--- a/src/main/java/com/wooyeon/yeon/user/service/encrypt/AesUtil.java
+++ b/src/main/java/com/wooyeon/yeon/user/service/encrypt/AesUtil.java
@@ -1,0 +1,38 @@
+package com.wooyeon.yeon.user.service.encrypt;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+@Log4j2
+public class AesUtil {
+
+    public static String decrypt(String ciphertext, String aesKeyBase64, String ivBase64) throws Exception {
+        // AES 키 및 IV 디코딩
+        byte[] aesKeyBytes = Base64.getDecoder().decode(aesKeyBase64);
+        byte[] ivBytes = Base64.getDecoder().decode(ivBase64);
+
+        // AES 키 및 IV 생성
+        SecretKey secretKey = new SecretKeySpec(aesKeyBytes, "AES");
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(ivBytes);
+
+        // Base64 디코딩
+        byte[] encryptedBytes = Base64.getDecoder().decode(ciphertext);
+
+        // AES 복호화 설정
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, ivParameterSpec);
+
+        // 복호화 수행
+        byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+
+        return new String(decryptedBytes, StandardCharsets.UTF_8);
+    }
+
+}

--- a/src/main/java/com/wooyeon/yeon/user/service/encrypt/RsaUtil.java
+++ b/src/main/java/com/wooyeon/yeon/user/service/encrypt/RsaUtil.java
@@ -72,4 +72,7 @@ public class RsaUtil {
     public static String sendPublicKey() {
         return base64EncodeToString(keyPair.getPublic().getEncoded());
     }
+    public static String sendPrivateKey() {
+        return base64EncodeToString(keyPair.getPrivate().getEncoded());
+    }
 }


### PR DESCRIPTION
1. AES Util 추가
2. 클라이언트에게 RSA로 암호화된 encryptedKey 받아와서 RSA 개인키로 복호화 decode하기
3. 1번의 decodeKey를 AES Key와 IV로 분리하기
4. AES Key와 IV 값으로 encryptedPassword Decode 하기
5. salt 생성 구현
6. SHA256 암호화 구현
7. 비밀번호+salt를 SHA256으로 암호화 후 USER에 저장
8. USER 엔티티에 salt 컬럼 추가