### PR TITLE
[REFACTOR] 회원가입 과정 중, DB에 insert하는 최종 비밀번호 암호화 방법을 SHA256+salt -> PassswordEncoder(Spring Security)로 변경 (로그인 비밀번호를 PasswordEncoder 사용으로 인한 충돌 수정)

### DIFF
--- a/src/main/java/com/wooyeon/yeon/config/security/SecurityConfig.java
+++ b/src/main/java/com/wooyeon/yeon/config/security/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                 .and()
                 .authorizeHttpRequests()
                 .antMatchers("/auth/**").permitAll()
-                .antMatchers("/encrypt/*").permitAll()
+                .antMatchers("/encrypt/**").permitAll()
                 .antMatchers("/users/**").permitAll()
                 .antMatchers("/api/*").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/wooyeon/yeon/user/controller/UserController.java
+++ b/src/main/java/com/wooyeon/yeon/user/controller/UserController.java
@@ -42,8 +42,7 @@ public class UserController {
         userEmitters.put(emailRequestDto.getEmail(), emitter);
 
         EmailResponseDto emailResponseDto = emailAuthService.sendEmail(emailRequestDto);
-
-        log.info("userEmitter: "+userEmitters);
+        log.info("userEmitter: " + userEmitters);
 
         // SSE 연결 여부 메시지 전송
         try {
@@ -52,7 +51,7 @@ public class UserController {
         } catch (IOException e) {
             emitter.completeWithError(e);
         }
-        log.info("SSE MSG : "+emitter);
+        log.info("SSE MSG : " + emitter);
 
         return emitter;
     }
@@ -64,8 +63,8 @@ public class UserController {
         EmailAuthResponseDto emailAuthResponseDto = emailAuthService.verifyEmail(auth);
         sendSseEmitter(emailAuthResponseDto);
 
-        log.info("verify request : "+auth);
-        log.info("verify 프론트에게 : "+emailAuthResponseDto);
+        log.info("verify request : " + auth);
+        log.info("verify 프론트에게 : " + emailAuthResponseDto);
 
         ModelAndView mv = new ModelAndView("email_auth_verify");
         mv.addObject("backgroundImg", emailAuthBackgroundImg);
@@ -101,7 +100,7 @@ public class UserController {
     public SseEmitter sendSseEmitter(EmailAuthResponseDto emailAuthResponseDto) {
         SseEmitter emitter = userEmitters.get(emailAuthResponseDto.getEmail());
 
-        log.info("SSE EMITTER(VERIFY) : "+emitter);
+        log.info("SSE EMITTER(VERIFY) : " + emitter);
 
         if (emitter != null) {
             try {

--- a/src/main/java/com/wooyeon/yeon/user/service/EmailAuthService.java
+++ b/src/main/java/com/wooyeon/yeon/user/service/EmailAuthService.java
@@ -46,35 +46,34 @@ public class EmailAuthService {
         // certification이 false이면서(=인증되지 않았으면서) 인증 코드 만료 시간이 지난 데이터 삭제
         deleteExpiredStatusIfExpired();
 
-        EmailResponseDto emailResponseDto;
-
         // 이메일 중복 확인 로직 추가
         if (validateDuplicated(emailRequestDto.getEmail())) {
 
             log.info("certification: " + emailAuthRepository.findEmailAuthByEmail(emailRequestDto.getEmail()).isCertification());
 
-            emailResponseDto = EmailResponseDto.builder()
+            EmailResponseDto emailResponseDto = EmailResponseDto.builder()
                     .statusCode(HttpStatus.SC_OK) // 오류코드 대신 200 부탁함
                     .email(emailRequestDto.getEmail())
                     .build();
 
-
             if (emailAuthRepository.findEmailAuthByEmail(emailRequestDto.getEmail()).isCertification()) {
                 emailResponseDto.updateStatusName("completed");
+                return emailResponseDto;
             } else {
                 emailResponseDto.updateStatusName("duplicated");
+                return emailResponseDto;
             }
 
         } else {
             // 이메일 인증 링크 발송
             sendEmailVerification(emailRequestDto);
-            emailResponseDto = EmailResponseDto.builder()
+            EmailResponseDto emailResponseDto = EmailResponseDto.builder()
                     .statusCode(HttpStatus.SC_ACCEPTED)
                     .email(emailRequestDto.getEmail())
                     .statusName("success")
                     .build();
+            return emailResponseDto;
         }
-        return emailResponseDto;
     }
 
     // authToken 발급 및 이메일 양식 설정, 전송

--- a/src/test/java/com/wooyeon/yeon/user/UserTest.java
+++ b/src/test/java/com/wooyeon/yeon/user/UserTest.java
@@ -1,18 +1,23 @@
-//package com.wooyeon.yeon.user;
-//
-//import com.wooyeon.yeon.user.domain.User;
-//import com.wooyeon.yeon.user.repository.UserRepository;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.security.crypto.password.PasswordEncoder;
-//
-//@SpringBootTest
-//public class UserTest {
-//    @Autowired
-//    private UserRepository userRepository;
-//    @Autowired
-//    private PasswordEncoder passwordEncoder;
+package com.wooyeon.yeon.user;
+
+import com.wooyeon.yeon.user.domain.User;
+import com.wooyeon.yeon.user.repository.UserRepository;
+import com.wooyeon.yeon.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.UUID;
+
+@SpringBootTest
+public class UserTest {
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private UserService userService;
 //
 //    @Test
 //    public void createUser() {
@@ -25,4 +30,29 @@
 //        userRepository.save(user);
 //    }
 //
-//}
+    // passwordEncoder 사용
+    /*@Test
+    public void pwEncoderUser() {
+        User user = User.builder()
+                .email("pw123@gmail.com")
+                .userCode(UUID.randomUUID())
+                .password(passwordEncoder.encode("1234"))
+                .build();
+        userRepository.save(user);
+    }*/
+
+    // sha256 + salt 사용
+    /*@Test
+    public void shaUser() {
+        String pw = userService.encryptSha256("1234");
+        String salt = userService.createSalt();
+        String fin = userService.encryptSha256("1234"+salt);
+        User usersh = User.builder()
+                .email("s123@gmail.com")
+                .userCode(UUID.randomUUID())
+                .password("{bcrypt}$2a$10$"+salt+fin)
+                .salt(salt)
+                .build();
+        userRepository.save(usersh);
+    }*/
+}


### PR DESCRIPTION
회원가입 과정 중, DB에 insert하는 최종 비밀번호 암호화 방법을 SHA256+salt -> PassswordEncoder(Spring Security)로 변경 (로그인 비밀번호를 PasswordEncoder 사용으로 인한 충돌 수정)

1. 비밀번호 암호화 방법을 SHA256+salt에서 Spring Security의 PasswordEncoder로 변경
2. UserTest 코드 추가 및 주석 처리