### PR TITLE
Update User-Profile Entity Relationship and Implement Code to Extract User Information from JwtToken for Profile Registration

### DIFF
--- a/src/main/java/com/wooyeon/yeon/user/domain/Profile.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/Profile.java
@@ -17,7 +17,7 @@ public class Profile {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "USER_ID")
+    @JoinColumn(name = "USER_ID", nullable = false)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/wooyeon/yeon/user/domain/Profile.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/Profile.java
@@ -16,7 +16,8 @@ public class Profile {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "profile")
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "USER_ID")
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/wooyeon/yeon/user/domain/User.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/User.java
@@ -52,8 +52,7 @@ public class User implements UserDetails {
     @Column
     private String salt;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "PROFILE_ID")
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "user")
     private Profile profile;
 
     @Column

--- a/src/test/java/com/wooyeon/yeon/user/UserTest.java
+++ b/src/test/java/com/wooyeon/yeon/user/UserTest.java
@@ -1,5 +1,6 @@
 package com.wooyeon.yeon.user;
 
+import com.wooyeon.yeon.user.domain.Profile;
 import com.wooyeon.yeon.user.domain.User;
 import com.wooyeon.yeon.user.repository.UserRepository;
 import com.wooyeon.yeon.user.service.UserService;
@@ -31,15 +32,26 @@ public class UserTest {
 //    }
 //
     // passwordEncoder 사용
-    /*@Test
+    @Test
     public void pwEncoderUser() {
         User user = User.builder()
-                .email("pw123@gmail.com")
+                .email("ez123@gmail.com")
                 .userCode(UUID.randomUUID())
-                .password(passwordEncoder.encode("1234"))
+                .password(passwordEncoder.encode("!aaaa0000"))
                 .build();
         userRepository.save(user);
-    }*/
+    }
+
+    /*
+    @Test
+    public void createProfileTest() {
+        Profile profile = Profile.builder()
+                .gender('F')
+                .nickname("hiz0")
+                .birthday("19951010")
+                .build();
+    }
+    */
 
     // sha256 + salt 사용
     /*@Test


### PR DESCRIPTION
1. User, Profile 엔티티 연관관계 수정 (주테이블 User -> Profile 변경)
2. JwtToken에서 유저 정보를 추출하고, 이를 사용하여 Profile 엔터티의 'user_id' 컬럼을 업데이트하는 코드 구현