### PR TITLE
[FEAT] Implement accessToken validation and profile registration status check

### DIFF
--- a/src/main/java/com/wooyeon/yeon/user/domain/User.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/User.java
@@ -42,15 +42,14 @@ public class User implements UserDetails {
 
     private String targetToken;
 
+    private String fcmToken;
+
     @Column
     @Builder.Default
     private boolean emailAuth = false;
 
     @Builder.Default
     private boolean phoneAuth = false;
-
-    @Column
-    private String salt;
 
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "user")
     private Profile profile;
@@ -68,7 +67,7 @@ public class User implements UserDetails {
     }
 
     @Builder
-    public User(String email, String phone, UUID userCode, String accessToken, String refreshToken, boolean emailAuth, boolean phoneAuth, String password, String salt) {
+    public User(String email, String phone, UUID userCode, String accessToken, String refreshToken, boolean emailAuth, boolean phoneAuth, String password, String fcmToken) {
         this.email = email;
         this.phone = phone;
         this.userCode = userCode;
@@ -76,7 +75,6 @@ public class User implements UserDetails {
         this.refreshToken = refreshToken;
         this.emailAuth = emailAuth;
         this.phoneAuth = phoneAuth;
-        this.salt = salt;
         this.password = password;
     }
 
@@ -89,7 +87,6 @@ public class User implements UserDetails {
     }
 
     public void updatePassword(String password) { this.password = password; }
-    public void updateSalt(String salt) { this.salt = salt; }
 
     public void setProfile(Profile profile) {
         this.profile = profile;

--- a/src/main/java/com/wooyeon/yeon/user/dto/ExpiredCheckDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/ExpiredCheckDto.java
@@ -1,0 +1,19 @@
+package com.wooyeon.yeon.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class ExpiredCheckDto {
+    @Getter
+    @Builder
+    public static class ExpiredCheckRequest {
+        private String accessToken;
+        private String refreshToken;
+    }
+
+    @Builder
+    @Getter
+    public static class ExpiredCheckResponse {
+        private int existsProfile;
+    }
+}

--- a/src/main/java/com/wooyeon/yeon/user/repository/UserRepository.java
+++ b/src/main/java/com/wooyeon/yeon/user/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     User findByEmail(String email);
     Optional<User> findOptionalByEmail(String email);
     Optional<User> findOptionalByUserId(Long userId);
+
+    User findByAccessToken(String accessToken);
 }


### PR DESCRIPTION
1. 헤더에서 accessToken 추출하는 메서드 추가(parseBearerToken)
2. 프론트엔드 요청의 헤더에서 추출한 accessToken이 만료되었는지 확인
3. 만료되었을 경우 EXCEPTIONCODE 반환
4. 만료되지 않았다면 사용자의 프로필 등록여부 반환 (200 : 등록, 3000 : 미등록)