### PR TITLE
[FEAT] SMS API를 이용한 SMS 인증 기능 구현 추가

### DIFF
--- a/src/main/java/com/wooyeon/yeon/user/domain/PhoneAuth.java
+++ b/src/main/java/com/wooyeon/yeon/user/domain/PhoneAuth.java
@@ -1,0 +1,44 @@
+package com.wooyeon.yeon.user.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhoneAuth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(length = 11, nullable = false)
+    private String phone; // 휴대폰 번호
+
+    @Column(length = 6, nullable = false)
+    private String verifyCode; // 인증코드 6자리(난수)
+
+    @Column(nullable = false)
+    private LocalDateTime expireDate; // 인증코드 만료일
+
+    private boolean certification; // 인증여부
+
+    @Builder
+    public PhoneAuth(String phone, String verifyCode, LocalDateTime expireDate, boolean certification) {
+        this.phone = phone;
+        this.verifyCode = verifyCode;
+        this.expireDate = expireDate;
+        this.certification = certification;
+    }
+
+    // 휴대폰 인증 완료
+    public void phoneVerifiedSuccess() {
+        this.certification = true;
+    }
+
+}

--- a/src/main/java/com/wooyeon/yeon/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package com.wooyeon.yeon.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@Getter
+public class LoginRequestDto {
+
+    private String email;
+    private String password;
+
+    public UsernamePasswordAuthenticationToken toAuthentication() {
+        return new UsernamePasswordAuthenticationToken(email, password);
+    }
+    public void updateEmail(String email) { this.email = email; }
+    public void updatePassword(String password) { this.password = password; }
+}

--- a/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/PhoneAuthRequestDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/PhoneAuthRequestDto.java
@@ -1,0 +1,13 @@
+package com.wooyeon.yeon.user.dto.smsAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class PhoneAuthRequestDto {
+    private String phone;
+    private String verifyCode;
+}

--- a/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/PhoneAuthResponseDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/PhoneAuthResponseDto.java
@@ -1,0 +1,16 @@
+package com.wooyeon.yeon.user.dto.smsAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class PhoneAuthResponseDto {
+    //    private String statusCode;
+    private String phoneAuth;
+    private String registerProc;
+}

--- a/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/PhoneInfoRequestDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/PhoneInfoRequestDto.java
@@ -1,0 +1,14 @@
+package com.wooyeon.yeon.user.dto.smsAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PhoneInfoRequestDto {
+    private String to;
+    // 문자 자동 읽어오기에 필요한 앱 시그니처
+    private String signature;
+}

--- a/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/SmsAuthRequestDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/SmsAuthRequestDto.java
@@ -1,0 +1,19 @@
+package com.wooyeon.yeon.user.dto.smsAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class SmsAuthRequestDto {
+    private String type;
+    private String contentType;
+    private String countryCode;
+    private String from;
+    private String content;
+    private List<SmsDto> messages;
+}

--- a/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/SmsAuthResponseDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/SmsAuthResponseDto.java
@@ -1,0 +1,19 @@
+package com.wooyeon.yeon.user.dto.smsAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class SmsAuthResponseDto {
+    private String requestId;
+    private LocalDateTime requestTime;
+    private String statusCode;
+    private String statusName;
+}

--- a/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/SmsDto.java
+++ b/src/main/java/com/wooyeon/yeon/user/dto/smsAuth/SmsDto.java
@@ -1,0 +1,16 @@
+package com.wooyeon.yeon.user.dto.smsAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class SmsDto {
+    private String to;
+//    private String content;
+
+}

--- a/src/main/java/com/wooyeon/yeon/user/repository/PhoneAuthRepository.java
+++ b/src/main/java/com/wooyeon/yeon/user/repository/PhoneAuthRepository.java
@@ -1,0 +1,24 @@
+package com.wooyeon.yeon.user.repository;
+
+import com.wooyeon.yeon.user.domain.PhoneAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface PhoneAuthRepository extends JpaRepository<PhoneAuth, Long> {
+    // 휴대폰 중복 체크
+    boolean existsByPhone(String phone);
+
+    PhoneAuth findByPhoneAndVerifyCode(String phone, String verifyCode);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PhoneAuth e WHERE e.expireDate < :currentDateTime")
+    void deleteExpiredRecords(@Param("currentDateTime") LocalDateTime currentDateTime);
+}

--- a/src/main/java/com/wooyeon/yeon/user/service/SmsAuthService.java
+++ b/src/main/java/com/wooyeon/yeon/user/service/SmsAuthService.java
@@ -1,0 +1,212 @@
+package com.wooyeon.yeon.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wooyeon.yeon.user.domain.PhoneAuth;
+import com.wooyeon.yeon.user.dto.smsAuth.*;
+import com.wooyeon.yeon.user.repository.PhoneAuthRepository;
+import com.wooyeon.yeon.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.client5.http.utils.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+@PropertySource("classpath:application-apikey.properties")
+@Slf4j
+@Service
+public class SmsAuthService {
+
+    private final PhoneAuthRepository phoneAuthRepository;
+    private final UserRepository userRepository;
+
+    @Value("${naver-cloud-sms.accessKey}")
+    private String accessKey;
+
+    @Value("${naver-cloud-sms.secretKey}")
+    private String secretKey;
+
+    @Value("${naver-cloud-sms.serviceId}")
+    private String serviceId;
+
+    @Value("${naver-cloud-sms.senderPhone}")
+    private String fromPhone;
+
+    // smsConfirmNum 만료 시간 (3분)
+    private static final long EXPIRATION_TIME = 3 * 60 * 1000;
+
+    public SmsAuthService(PhoneAuthRepository phoneAuthRepository, UserRepository userRepository) {
+        this.phoneAuthRepository = phoneAuthRepository;
+        this.userRepository = userRepository;
+    }
+
+    public SmsAuthResponseDto sendSms(PhoneInfoRequestDto phoneInfoRequestDto) {
+        // 인증 코드 만료 시간이 지난 데이터 삭제
+        deleteExpiredStatusIfExpired();
+
+        // smsDto 설정
+        SmsDto smsDto = new SmsDto();
+        smsDto.setTo(phoneInfoRequestDto.getTo());
+
+        String appSignature = phoneInfoRequestDto.getSignature();
+
+        // 휴대폰 번호가 중복일 경우 프론트엔드에게 statusName으로 중복됨을 알려주기(statusCode가 500이 나 버리면 안되기 때문에)
+        if (validateDuplicated(smsDto.getTo())) {
+            SmsAuthResponseDto smsAuthResponseDto = SmsAuthResponseDto.builder()
+                    .requestId("duplication")
+                    .statusName("duplicated")
+                    .statusCode("202")
+                    .requestTime(LocalDateTime.now())
+                    .build();
+            return smsAuthResponseDto;
+        }
+        SmsAuthResponseDto smsAuthResponseDto;
+        try {
+            smsAuthResponseDto = createMessage(smsDto, appSignature);
+        } catch (JsonProcessingException | UnsupportedEncodingException | NoSuchAlgorithmException |
+                 InvalidKeyException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        return smsAuthResponseDto;
+    }
+
+    // 네이버 SMS API를 통한 message 생성 및 전송, PhoneAuth에 데이터 저장
+    public SmsAuthResponseDto createMessage(SmsDto smsDto, String appSignature) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+        //휴대폰 인증 번호 생성
+        String smsConfirmNum = createSmsKey();
+
+        Long time = System.currentTimeMillis();
+
+        // 네이버 sms api 헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-ncp-apigw-timestamp", time.toString());
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", makeSignature(time));
+
+        List<SmsDto> smsDtoList = new ArrayList<>();
+        smsDtoList.add(smsDto);
+
+        // 네이버 sms api 이용
+        SmsAuthRequestDto request = SmsAuthRequestDto.builder()
+                .type("SMS")
+                .contentType("COMM")
+                .countryCode("82")
+                .from(fromPhone)
+                .content("[우연] 인증번호를 입력해주세요\n" + smsConfirmNum + "\n\n" + appSignature)
+                .messages(smsDtoList)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String body = objectMapper.writeValueAsString(request);
+        HttpEntity<String> httpBody = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        SmsAuthResponseDto response = restTemplate.postForObject(new URI("https://sens.apigw.ntruss.com/sms/v2/services/" + this.serviceId + "/messages"), httpBody, SmsAuthResponseDto.class);
+
+        // phoneAuth에 저장
+        LocalDateTime expireDate = LocalDateTime.now().plusSeconds(EXPIRATION_TIME / 1000);
+        PhoneAuth phoneAuth = PhoneAuth.builder()
+                .phone(smsDto.getTo())
+                .verifyCode(smsConfirmNum)
+                .expireDate(expireDate)
+                .build();
+        phoneAuthRepository.save(phoneAuth);
+
+        return response;
+    }
+
+    // 휴대폰 번호 인증 처리
+    @Transactional
+    public PhoneAuthResponseDto verifyPhone(PhoneAuthRequestDto phoneAuthRequestDto) {
+        // 휴대폰 번호와 인증 코드가 일치하는 지 확인
+        PhoneAuth phoneAuth = phoneAuthRepository.findByPhoneAndVerifyCode(phoneAuthRequestDto.getPhone(), phoneAuthRequestDto.getVerifyCode());
+
+        PhoneAuthResponseDto phoneAuthResponseDto;
+        // 만약 일치 한다면 PhoneAuth(휴대폰 인증여부)를 success로 반환
+        if (phoneAuth != null) {
+            phoneAuthResponseDto = PhoneAuthResponseDto.builder()
+                    .phoneAuth("success")
+                    .registerProc("none") // 나중에 프로필, 이용약관 동의까지 구현 후 변경 요망
+                    .build();
+            phoneAuth.phoneVerifiedSuccess(); // 해당 데이터의 certification(인증완료) 값을 true로 설정
+
+        } else { // 일치하지 않으면 fail 값을 반환
+            phoneAuthResponseDto = PhoneAuthResponseDto.builder()
+                    .phoneAuth("fail")
+                    .registerProc(null) // registerProc은 null로 설정
+                    .build();
+        }
+        return phoneAuthResponseDto;
+    }
+
+    // NAVER SMS API signature 생성
+    public String makeSignature(Long time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        String space = " ";
+        String newLine = "\n";
+        String method = "POST";
+        String url = "/sms/v2/services/" + this.serviceId + "/messages";
+        String timestamp = time.toString();
+        String accessKey = this.accessKey;
+        String secretKey = this.secretKey;
+
+        String message = method +
+                space +
+                url +
+                newLine +
+                timestamp +
+                newLine +
+                accessKey;
+
+        SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(signingKey);
+
+        byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+        String encodeBase64String = Base64.encodeBase64String(rawHmac);
+
+        return encodeBase64String;
+    }
+
+    // 인증코드 생성
+    public String createSmsKey() {
+        int key = ThreadLocalRandom.current().nextInt(100000,999999);
+        return Integer.toString(key);
+    }
+
+    // 휴대폰 번호 중복 확인 로직 구현
+    private boolean validateDuplicated(String phone) {
+        // 중복된 휴대폰 번호가 이미 PhoneAuth 테이블에 존재한다면 예외 처리
+        return phoneAuthRepository.existsByPhone(phone);
+    }
+
+    // PhoneAuth에 있는 expiredDate가 지난 데이터 삭제
+    @Transactional
+    public void deleteExpiredStatusIfExpired() {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        phoneAuthRepository.deleteExpiredRecords(currentDateTime);
+    }
+
+}


### PR DESCRIPTION
1. SMS 인증을 위한 PhoneAuth Entity 추가
2. PhoneAuthRepository 추가
- 휴대폰 중복체크
- 휴대폰 & 인증코드 확인
- exprireDate(만료기간)가 지난 데이터 삭제)
3. SMS 인증을 위한 Dto 생성